### PR TITLE
Update the pykitops docs to better fit the KitOps format

### DIFF
--- a/docs/before-you-begin.md
+++ b/docs/before-you-begin.md
@@ -1,4 +1,4 @@
-# Before You Begin
+## Before You Begin
 
 This project was created using Python v3.12, but works with Python versions >= 3.10.
 
@@ -13,7 +13,7 @@ To determine if the Kit CLI is installed in your environment:
    ```bash
    kit version
    ```
-   
+
 1. You should see output similar to the following:
 
     ```
@@ -39,23 +39,27 @@ Alternatively, ModelKits can be stored in any OCI 1.1-compliant container regist
 ### 3/ Set Your Environment
 
 1. In the root directory of your project (the *"Project directory"*) create a `.env` file.
-1. Edit the `.env` file by adding an entry for your `JOZU_USERNAME`, your `JOZU_PASSWORD` and your `JOZU_NAMESPACE` (this should match the repository name you'll be pushing to in the regsitry). If you're *not* using the Jozu Hub you'll also need to set the `JOZU_REGISTRY` variable to point to the URL for your registry.
+2. Edit the `.env` file by adding an entry for your `JOZU_USERNAME`, your `JOZU_PASSWORD` and your `JOZU_NAMESPACE` (this should match the repository name you'll be pushing to in the regsitry). If you're *not* using the Jozu Hub you'll also need to set the `JOZU_REGISTRY` variable to point to the URL for your registry.
 
-   An example `.env` file for Jozu Hub will look like this:
-   
-        JOZU_USERNAME=brett@jozu.org
-        JOZU_PASSWORD=my_password
-        JOZU_NAMESPACE=brett
+    An example `.env` file for Jozu Hub will look like this:
+
+    ```bash
+      JOZU_USERNAME=brett@jozu.org
+      JOZU_PASSWORD=my_password
+      JOZU_NAMESPACE=brett
+    ```
 
     An example `.env` file for another registry will look like this:
-        
-        JOZU_REGISTRY=hub.docker.com
-        JOZU_USERNAME=brett@jozu.org
-        JOZU_PASSWORD=my_password
-        JOZU_NAMESPACE=brett
+
+    ```bash
+      JOZU_REGISTRY=hub.docker.com
+      JOZU_USERNAME=brett@jozu.org
+      JOZU_PASSWORD=my_password
+      JOZU_NAMESPACE=brett
+    ```
 
     - The Kitops Manager uses the entries in the `.env` file to login to [Jozu.ml](https://www.jozu.ml).
     - As an alternative to using a `.env` file, you can create Environment Variables for each of the entries above.
-1. Be sure to save the changes to your .env file before continuing.
+3. Be sure to save the changes to your .env file before continuing.
 
 That's it! You can check out the How To Guide to see an example of how to use the SDK.

--- a/docs/how-to-guides.md
+++ b/docs/how-to-guides.md
@@ -1,64 +1,70 @@
+# How-to Guides
+
 This part of the project documentation focuses on a **problem-oriented** approach. You'll tackle common tasks that you might have, with the help of the code provided in this project.
 
 ## How To Create A Kitfile Object?
 
-Whether you're working with an existing ModelKit's Kitfile, 
+Whether you're working with an existing ModelKit's Kitfile,
 or starting from nothing, the `kitops` package can help you
 get this done.
 
-Install the `kitops` package from PYPI into your project's environment 
+Install the `kitops` package from PYPI into your project's environment
 with the following command
 
-```
+```sh
 pip install kitops
 ```
 
 Inside of your code you can now import the `Kitfile`
 class from the `kitops.modelkit.kitfile` module:
 
-    # your code
-    from kitops.modelkit.kitfile import Kitfile
+```python
+from kitops.modelkit.kitfile import Kitfile
+```
 
 After you've imported the class, you can use it
 to create a Kitfile object from an existing ModelKit's Kitfile:
 
-    # your code
-    from kitops.modelkit.kitfile import Kitfile
+```python
+from kitops.modelkit.kitfile import Kitfile
 
-    my_kitfile = Kitfile(path='/path/to/Kitfile')
-    print(my_kitfile.to_yaml())
-    
-    # The output should match the contents of the Kitfile
-    # located at: /path/to/Kitfile
+my_kitfile = Kitfile(path='/path/to/Kitfile')
+print(my_kitfile.to_yaml())
+
+# The output should match the contents of the Kitfile
+# located at: /path/to/Kitfile
+```
 
 You can also create an empty Kitfile from scratch:
 
-    # your code
-    from kitops.modelkit.kitfile import Kitfile
+```python
+from kitops.modelkit.kitfile import Kitfile
 
-    my_kitfile = Kitfile()
-    print(my_kitfile.to_yaml())
+my_kitfile = Kitfile()
+print(my_kitfile.to_yaml())
 
-    # OUTPUT: {}
+# OUTPUT: {}
+```
 
-Regardless of how you created the Kitfile, you can update its contents 
+Regardless of how you created the Kitfile, you can update its contents
 like you would do with any other python dictionary:
 
-    # your code
-    my_kitfile.manifestVersion = "3.0"
-    my_kitfile.package = {
-        "name": "Another-Package",
-        "version": "3.0.0",
-        "description": "Another description",
-        "authors": ["Someone"]
-    }
-    print(my_kitfile.to_yaml())
+```python
+my_kitfile.manifestVersion = "3.0"
+my_kitfile.package = {
+    "name": "Another-Package",
+    "version": "3.0.0",
+    "description": "Another description",
+    "authors": ["Someone"]
+}
+print(my_kitfile.to_yaml())
 
-    # OUTPUT:
-    #   manifestVersion: '3.0'
-    #   package:
-    #       name: Another-Package
-    #       version: 3.0.0
-    #       description: Another description
-    #       authors:
-    #       - Someone
+# OUTPUT:
+#   manifestVersion: '3.0'
+#   package:
+#       name: Another-Package
+#       version: 3.0.0
+#       description: Another description
+#       authors:
+#       - Someone
+```

--- a/docs/reference/kit.md
+++ b/docs/reference/kit.md
@@ -1,4 +1,4 @@
-# kit Commands
+## Kit Commands
 
 These functions provide programmatic access to the KitOps Command-Line Interface.
 
@@ -22,27 +22,3 @@ You can import them all from `kitops.cli.kit`
 ```python
 import kitops.cli.kit as kit
 ```
-
-:::kitops.cli.kit.info
-
-:::kitops.cli.kit.inspect
-
-:::kitops.cli.kit.list
-
-:::kitops.cli.kit.login
-
-:::kitops.cli.kit.logout
-
-:::kitops.cli.kit.pack
-
-:::kitops.cli.kit.pull
-
-:::kitops.cli.kit.push
-
-:::kitops.cli.kit.remove
-
-:::kitops.cli.kit.tag
-
-:::kitops.cli.kit.unpack
-
-:::kitops.cli.kit.version

--- a/docs/reference/kitfile.md
+++ b/docs/reference/kitfile.md
@@ -1,9 +1,7 @@
-# `Kitfile` class
+## `Kitfile` class
 
 You can import the `Kitfile` class from `kitops.modelkit.kitfile`:
 
 ```python
 from kitops.modelkit.kitfile import Kitfile
 ```
-
-::: kitops.modelkit.kitfile.Kitfile

--- a/docs/reference/manager.md
+++ b/docs/reference/manager.md
@@ -1,9 +1,7 @@
-# `ModelKitManager` class
+## `ModelKitManager` class
 
 You can import the `ModelKitManager` class from `kitops.modelkit.manager`:
 
 ```python
 from kitops.modelkit.manager import ModelKitManager
 ```
-
-::: kitops.modelkit.manager.ModelKitManager

--- a/docs/reference/reference.md
+++ b/docs/reference/reference.md
@@ -1,9 +1,7 @@
-# `ModelKitReference` class
+## `ModelKitReference` class
 
 You can import the `ModelKitReference` class from `kitops.modelkit.reference`:
 
 ```python
 from kitops.modelkit.reference import ModelKitReference
 ```
-
-::: kitops.modelkit.reference.ModelKitReference

--- a/docs/reference/user.md
+++ b/docs/reference/user.md
@@ -1,9 +1,7 @@
-# `UserCredentials` class
+## `UserCredentials` class
 
 You can import the `UserCredentials` class from `kitops.modelkit.user`:
 
 ```python
 from kitops.modelkit.user import UserCredentials
 ```
-
-::: kitops.modelkit.user.UserCredentials


### PR DESCRIPTION
This PR updates the md content to make it fit better inside the KitOps docs style and format. With these updates the right-side ToC is generated better and also allows us to properly import and reference some of these md files from a parent md.