### PR TITLE
Simplify `modelkit/utils.py` functions

### DIFF
--- a/kitops/modelkit/utils.py
+++ b/kitops/modelkit/utils.py
@@ -54,8 +54,7 @@ def validate_dict(value: Dict[str, Any], allowed_keys: Set[str]):
     if not isinstance(value, dict):
         raise ValueError(
                 f"Expected a dictionary but got {type(value).__name__}")
-    value_keys = set(value.keys())
-    unallowed_keys = value_keys.difference(allowed_keys) 
+    unallowed_keys = set(value.keys()) - allowed_keys
     if len(unallowed_keys) > 0:
         raise ValueError("Found unallowed key(s): " +
                          f"{', '.join(unallowed_keys)}")
@@ -78,34 +77,17 @@ def clean_empty_items(d: Any) -> Any:
         Any: Cleaned dictionary or list.
     """
     if isinstance(d, dict):
-        cleaned_dict = {}
-        for k, v in d.items():
-            if k.strip() and v is not None:
-                if isinstance(v, (dict, list)):
-                    cleaned_v = clean_empty_items(v)
-                    if cleaned_v:  # Only add non-empty items
-                        cleaned_dict[k] = cleaned_v
-                elif isinstance(v, str) and v.strip() != "":
-                    cleaned_dict[k] = v
-                elif not isinstance(v, str):
-                    cleaned_dict[k] = v
-        return cleaned_dict
+        return {
+            k: clean_empty_items(v)
+            for k, v in d.items()
+            if v is not None and (v.strip() != "" if isinstance(v, str) else True)
+        }
 
     elif isinstance(d, list):
-        cleaned_list = []
-        for item in d:
-            if item is not None:
-                if isinstance(item, (dict, list)):
-                    cleaned_item = clean_empty_items(item)
-                    if cleaned_item:  # Only add non-empty items
-                        cleaned_list.append(cleaned_item)
-                elif isinstance(item, str) and item.strip() != "":
-                    cleaned_list.append(item)
-                elif not isinstance(item, str):
-                    cleaned_list.append(item)
-        return cleaned_list
+        return [clean_empty_items(item) for item in d if item]
 
-    return d
+    if d:
+        return d
 
 def get_or_create_directory(directory: str) -> str:
     """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 import unittest
 from unittest.mock import patch
 from kitops.modelkit.utils import load_environment_variables
@@ -50,6 +51,49 @@ class TestLoadEnvironmentVariables(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             load_environment_variables()
         self.assertIn("Missing JOZU_USERNAME or JOZU_PASSWORD", str(context.exception))
+
+
+@pytest.mark.parametrize(
+    "input_dict, allowed_keys, should_raise, expected_message",
+    [
+        ({"a": 1, "b": 2}, {"a", "b"}, False, None),
+        ({"a": 1, "b": 2}, {"a"}, True, "Found unallowed key(s): b"),
+        ({"a": 1, "d": 2}, {"a", "b", "c"}, True, "Found unallowed key(s): d"),
+        (["a", "b"], {"a", "b"}, True, "Expected a dictionary but got list"),
+    ],
+)
+def test_validate_dict(
+    input_dict, allowed_keys, should_raise, expected_message
+) -> None:
+    if should_raise:
+        with pytest.raises(ValueError) as excinfo:
+            validate_dict(input_dict, allowed_keys)
+        assert expected_message in str(excinfo.value)
+    else:
+        try:
+            validate_dict(input_dict, allowed_keys)
+        except ValueError:
+            pytest.fail("validate_dict raised ValueError unexpectedly!")
+
+@pytest.mark.parametrize(
+    "d, expected",
+    [
+        ({"a": "", "b": "c", "d": None}, {"b": "c"}),
+        (["", "a", None], ["a"]),
+        ({"a": {"b": "", "c": "d"}, "e": None}, {"a": {"c": "d"}}),
+        (["", ["a", None], None], [["a"]]),
+        (
+            {"a": ["", "b", None], "c": {"d": "", "e": "f"}},
+            {"a": ["b"], "c": {"e": "f"}},
+        ),
+        ({"a": "b", "c": "d"}, {"a": "b", "c": "d"}),
+        ({}, {}),
+        ([], []),
+    ],
+)
+def test_clean_empty_items(d, expected) -> None:
+    assert clean_empty_items(d) == expected
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary 

Proposing a few minor changes to the code in `kitops/modelkit/utils.py` for simplifying the code. Added tests for the two modified functions, but was not clear if `pytest` or `unittest` was the preferred framework for testing. I used `pytest` as it's more familiar. The goal was to reduce lines of code, while maintaining functionality and readability.

## Optimizations and code improvements:

* [`kitops/modelkit/utils.py`](diffhunk://#diff-36e99c352a7abac2da9ebed4d75ec8ff20d18a485ed9fcec9756ba5ab6e894a3L57-R57): Modified `validate_dict` to remove single-use variable.
* [`kitops/modelkit/utils.py`](diffhunk://#diff-36e99c352a7abac2da9ebed4d75ec8ff20d18a485ed9fcec9756ba5ab6e894a3L81-R89): Refactored `clean_empty_items` to reduce code complexity and improve readability.

## Test enhancements:

* [`tests/test_utils.py`](diffhunk://#diff-33c13e0b177bacd2f02e29bcb8aea5b49e7ce34901fd8f41fefb65defba1bd33R55-R97): Add parameterized tests for `validate_dict` function to cover various scenarios.
* [`tests/test_utils.py`](diffhunk://#diff-33c13e0b177bacd2f02e29bcb8aea5b49e7ce34901fd8f41fefb65defba1bd33R55-R97): Add parameterized tests for `clean_empty_items` function with multiple test-cases.