### PR TITLE
Uses `pathlib.Path` method in `kitfile.py`

### DIFF
--- a/kitops/modelkit/kitfile.py
+++ b/kitops/modelkit/kitfile.py
@@ -192,11 +192,10 @@ class Kitfile:
 
         # try to load the kitfile
         try:
-            data = yaml.safe_load(kitfile_path.read_text("utf-8"))
+            data = yaml.safe_load(kitfile_path.read_text(encoding="utf-8"))
 
         except yaml.YAMLError as e:
-            if hasattr(e, "problem_mark"):
-                mark = e.problem_mark
+            if mark := getattr(e, "problem_mark", None):
                 raise yaml.YAMLError(
                     "Error parsing Kitfile at "
                     + f"line{mark.line + 1}, "
@@ -390,7 +389,7 @@ class Kitfile:
             >>> kitfile = Kitfile()
             >>> kitfile.save("path/to/Kitfile")
         """
-        Path(path).write_text(self.to_yaml(), "utf-8")
+        Path(path).write_text(self.to_yaml(), encoding="utf-8")
 
         if print:
             self.print()

--- a/kitops/modelkit/kitfile.py
+++ b/kitops/modelkit/kitfile.py
@@ -192,9 +192,8 @@ class Kitfile:
 
         # try to load the kitfile
         try:
-            with open(kitfile_path, "r") as kitfile:
-                # Load the yaml data
-                data = yaml.safe_load(kitfile)
+            data = yaml.safe_load(kitfile_path.read_text("utf-8"))
+
         except yaml.YAMLError as e:
             if hasattr(e, "problem_mark"):
                 mark = e.problem_mark
@@ -391,8 +390,7 @@ class Kitfile:
             >>> kitfile = Kitfile()
             >>> kitfile.save("path/to/Kitfile")
         """
-        with open(path, "w") as file:
-            file.write(self.to_yaml())
+        Path(path).write_text(self.to_yaml(), "utf-8")
 
         if print:
             self.print()


### PR DESCRIPTION
## Summary of changes

- Replaces context manager `with open` syntax to use `pathlib.Path.read_text` and `pathlib.Path.write_text` methods.

- Includes `encoding="utf-8"` when reading/writing files, which should help avoid any issues with files shared across OSes or regions

- Used walrus operator `:=` for conditional in YAML error handling for conciseness

## Outcome

- Trims a few lines of code and uses modern python syntax.
- Should help avoid errors between OSes or regions by enforcing standardized read/write file encoding

